### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/LABS/kafka-wo-zoo/docker-compose.yml
+++ b/LABS/kafka-wo-zoo/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   #     - ./data/zookeeper/datalog:/datalog
 
   kafka1:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     container_name: kafka1
     ports:
       - 9091:9091
@@ -100,7 +100,7 @@ services:
       - ./data/kafka1/data:/var/lib/kafka/data    
 
   kafka2:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     container_name: kafka2
     ports:
       - 9092:9092
@@ -123,7 +123,7 @@ services:
       - ./data/kafka2/data:/var/lib/kafka/data    
 
   kafka3:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     container_name: kafka3
     ports:
       - 9093:9093


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)